### PR TITLE
Fix sync methods not passing options to toJSON

### DIFF
--- a/backbone-storage-sync.js
+++ b/backbone-storage-sync.js
@@ -22,7 +22,7 @@
                 instance.set(instance.idAttribute, _.result(this, 'syncKey'));
             }
 
-            var json = instance.toJSON();
+            var json = instance.toJSON(options);
             var data = JSON.stringify(json);
             this._syncSet(data);
 
@@ -50,7 +50,7 @@
         update: function (instance, options, deferred) {
             var defaultStr = instance instanceof Backbone.Model ? JSON.stringify({}) : JSON.stringify([]),
                 storedData = this._syncGet() || defaultStr,
-                json = instance.toJSON();
+                json = instance.toJSON(options);
 
             var data = JSON.stringify(json);
             this._syncSet(data);
@@ -63,7 +63,7 @@
         patch: function (instance, options, deferred) {
             var defaultStr = instance instanceof Backbone.Model ? JSON.stringify({}) : JSON.stringify([]),
                 storedData = this._syncGet() || defaultStr,
-                json = _.merge(JSON.parse(storedData), instance.toJSON());
+                json = _.merge(JSON.parse(storedData), instance.toJSON(options));
 
             var data = JSON.stringify(json);
             this._syncSet(data);

--- a/test/backbone-storage-sync-test.js
+++ b/test/backbone-storage-sync-test.js
@@ -307,6 +307,24 @@ describe('StorageSyncMixin', function () {
                     done();
                 });
             });
+
+            it('should pass options to toJSON()', function (done) {
+                var unstoredModel = new UnstoredModel();
+                sinon.stub(unstoredModel, 'toJSON');
+                var options = { foo: 'bar' };
+
+                // act
+                unstoredModel.save(null, options);
+
+                _.defer(function () {
+                    expect(unstoredModel.toJSON.calledWithMatch(options)).to.be.true;
+
+                    // cleanup
+                    unstoredModel.toJSON.restore();
+
+                    done();
+                });
+            });
         });
 
         describe('save (update)', function () {
@@ -367,6 +385,25 @@ describe('StorageSyncMixin', function () {
                     done();
                 });
             });
+
+            it('should pass options to toJSON', function (done) {
+                var storedModel = new StoredModel({ id: syncKey });
+                storedModel.set('saved', 'updated');
+                sinon.stub(storedModel, 'toJSON');
+                var options = { foo: 'bar' };                
+
+                // act
+                storedModel.save(null, options);
+
+                _.defer(function () {
+                    expect(storedModel.toJSON.calledWithMatch(options)).to.be.true;
+
+                    // cleanup
+                    storedModel.toJSON.restore();
+
+                    done();
+                });
+            });            
         });
 
         describe('save (patch)', function () {
@@ -414,6 +451,25 @@ describe('StorageSyncMixin', function () {
                     done();
                 });
             });
+
+            it('should pass options to toJSON', function (done) {
+                var storedModel = new StoredModel({ id: syncKey });
+                storedModel.set('saved', 'updated');
+                sinon.stub(storedModel, 'toJSON');
+                var options = { foo: 'bar', patch: true };                    
+
+                // act
+                storedModel.save(null, options);
+
+                _.defer(function () {
+                    expect(storedModel.toJSON.calledWithMatch(options)).to.be.true;
+
+                    // cleanup
+                    storedModel.toJSON.restore();
+                    
+                    done();
+                });
+            });            
         });
 
         describe('destroy', function () {


### PR DESCRIPTION
Backbone passes options to toJSON, so the mixin should as well.